### PR TITLE
Allow 7.6.0 as a minimum qfsd version

### DIFF
--- a/compute/README.md
+++ b/compute/README.md
@@ -4,7 +4,7 @@
 
 ## Terraform Documentation
 
-> ℹ️ **Note:** This repository uses documentation generated with Terraform-Docs.  
+> ℹ️ **Note:** This repository uses documentation generated with Terraform-Docs.
 
 ## Requirements
 
@@ -44,7 +44,7 @@
 | <a name="input_q_cluster_floating_ips"></a> [q\_cluster\_floating\_ips](#input\_q\_cluster\_floating\_ips) | The number of floating ips associated with the Qumulo cluster. | `number` | `12` | no |
 | <a name="input_q_cluster_fw_ingress_cidrs"></a> [q\_cluster\_fw\_ingress\_cidrs](#input\_q\_cluster\_fw\_ingress\_cidrs) | OPTIONAL: GCP additional firewall ingress CIDRs for the Qumulo cluster | `string` | `null` | no |
 | <a name="input_q_cluster_name"></a> [q\_cluster\_name](#input\_q\_cluster\_name) | Qumulo cluster name | `string` | `"CNQ"` | no |
-| <a name="input_q_cluster_version"></a> [q\_cluster\_version](#input\_q\_cluster\_version) | Qumulo cluster software version | `string` | `"7.5.0"` | no |
+| <a name="input_q_cluster_version"></a> [q\_cluster\_version](#input\_q\_cluster\_version) | Qumulo cluster software version | `string` | `"7.6.0"` | no |
 | <a name="input_q_debian_package"></a> [q\_debian\_package](#input\_q\_debian\_package) | Debian or RHL package | `bool` | `true` | no |
 | <a name="input_q_existing_deployment_unique_name"></a> [q\_existing\_deployment\_unique\_name](#input\_q\_existing\_deployment\_unique\_name) | OPTIONAL: The deployment\_unique\_name of the previous deployed cluster you want to replace | `string` | `null` | no |
 | <a name="input_q_fqdn_name"></a> [q\_fqdn\_name](#input\_q\_fqdn\_name) | OPTIONAL: The Fully Qualified Domain Name (FQDN) for Route 53 Private Hosted Zone | `string` | `null` | no |

--- a/compute/module/sub-modules/qprovisioner/scripts/provision.py
+++ b/compute/module/sub-modules/qprovisioner/scripts/provision.py
@@ -595,7 +595,7 @@ def validate_qfsd_version(qfsd_version: str, firestore: FirestoreManager) -> Non
     """Validate that Qumulo Core version meets minimum requirements"""
     # Check for version greater than 7.6.0 to support CNQ on GCP
     check_version = vercomp(qfsd_version, "7.6.0")
-    if check_version == 2:  # qfsd_version > 7.6.0
+    if check_version == 0 or check_version == 2:  # qfsd_version >= 7.6.0
         logging.info("Qumulo Core >= 7.6.0")
     else:
         error_msg = "Qumulo Core version >= 7.6.0 is required. If this is a new deployment destroy it and redeploy with >= 7.6.0."

--- a/compute/module/sub-modules/qprovisioner/scripts/provision.py
+++ b/compute/module/sub-modules/qprovisioner/scripts/provision.py
@@ -593,7 +593,7 @@ def survey_cluster_state(config: ProvisioningConfig, firestore: FirestoreManager
 
 def validate_qfsd_version(qfsd_version: str, firestore: FirestoreManager) -> None:
     """Validate that Qumulo Core version meets minimum requirements"""
-    # Check for version greater than 7.6.0 to support CNQ on GCP
+    # Check for version greater or equal to 7.6.0 to support CNQ on GCP
     check_version = vercomp(qfsd_version, "7.6.0")
     if check_version == 0 or check_version == 2:  # qfsd_version >= 7.6.0
         logging.info("Qumulo Core >= 7.6.0")


### PR DESCRIPTION
This addressed a bug where only qfsd versions above 7.6.0 are allowed. Relevant comments are also updated